### PR TITLE
Preserve the datatype

### DIFF
--- a/tools/reporter/reader.py
+++ b/tools/reporter/reader.py
@@ -165,7 +165,7 @@ class RecorderReader:
             tend = struct.unpack('i', line[5:9])[0]
             res = struct.unpack('i', line[9:13])[0]
             funcId = struct.unpack('B', line[13:14])[0]
-            args = line[15:].decode('utf-8').split(' ')
+            args = [int(i) if i.isdigit() else i for i in line[15:].split(' ')]
             records.append(Record(rank, status, tstart, tend, funcId, args, res))
 
         return records


### PR DESCRIPTION
Currently, when arguments are generated in trace files all of them result in `String` data type, so every time I try to match source and destinations (rank is int, but arguments are in string), I had to change the type. This will preserve the type from original MPI calls. 

If you think this will be extra/inefficient here, please ignore it. I will attend to them in the match code.