### PR TITLE
Fixing string import bug with gcc 11.2

### DIFF
--- a/tools/build_offset_intervals.cpp
+++ b/tools/build_offset_intervals.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <vector>
-#include <string.h>
+#include <string>
 #include <unordered_map>
 #include <algorithm>
 extern "C" {                            // Needed to mix linking C and C++ sources


### PR DESCRIPTION
Error at compilation (string out of scope) when compiling with GCC 11.2.

No tests exist so it's is not possible to conclude that old string (string.h) is used on purpose.
If <string.h> was used on purpose instead of <string> you should consider to replace it by <cstring>.