### PR TITLE
Fix timestamps in timeline (aka Chrome trace) conversion

### DIFF
--- a/include/recorder-utils.h
+++ b/include/recorder-utils.h
@@ -2,11 +2,13 @@
 #define _RECORDER_UTILS_H_
 
 #include <fcntl.h>
+#include <pthread.h>
 
 void utils_init();
 void utils_finalize();
 void* recorder_malloc(size_t size);
 void recorder_free(void* ptr, size_t size);
+pthread_t recorder_gettid(void);
 long get_file_size(const char *filename);       // return the size of a file
 int accept_filename(const char *filename);      // if include the file in trace
 double recorder_wtime(void);                    // return the timestamp

--- a/include/recorder.h
+++ b/include/recorder.h
@@ -163,7 +163,7 @@
                                                                                     \
     Record *record = recorder_malloc(sizeof(Record));                               \
     record->func_id = get_function_id_by_name(#func);                               \
-    record->tid = pthread_self();                                                   \
+    record->tid = recorder_gettid();                                                \
     logger_record_enter(record);                                                    \
     record->tstart = recorder_wtime();                                              \
     ret res = RECORDER_REAL_CALL(func) real_args ;                                  \

--- a/lib/recorder-cuda-profiler.c
+++ b/lib/recorder-cuda-profiler.c
@@ -134,7 +134,7 @@ Record* create_recorder_record(CUpti_ActivityKernel5 *kernel) {
     Record *record = recorder_malloc(sizeof(Record));
     record->func_id = RECORDER_USER_FUNCTION;
     record->level = 0;
-    record->tid = pthread_self();
+    record->tid = recorder_gettid();
     record->tstart = (kernel->start - startTimestamp)/10e9;
     record->tstart = (kernel->end - startTimestamp)/10e9;
     record->arg_count = 2;

--- a/lib/recorder-function-profiler.c
+++ b/lib/recorder-function-profiler.c
@@ -25,7 +25,7 @@ func_hash_t* func_table;
 
 
 void* compose_func_hash_key(void* func, int *key_len) {
-    pthread_t tid = pthread_self();
+    pthread_t tid = recorder_gettid();
     *key_len = sizeof(pthread_t) + sizeof(void*);
     void* key = recorder_malloc(*key_len);
     memcpy(key, &tid, sizeof(pthread_t));
@@ -89,7 +89,7 @@ void __cyg_profile_func_exit (void *func,  void *caller)
         Record *record = recorder_malloc(sizeof(Record));
         record->func_id = RECORDER_USER_FUNCTION;
         record->level = 0;
-        record->tid = pthread_self();
+        record->tid = recorder_gettid();
         record->tstart = entry->tstart_head->tstart;
         record->tend = recorder_wtime();
         record->arg_count = 2;

--- a/lib/recorder-utils.c
+++ b/lib/recorder-utils.c
@@ -1,12 +1,13 @@
 #define _GNU_SOURCE
+#include <unistd.h>
 #include <sys/time.h>   // for gettimeofday()
 #include <stdarg.h>     // for va_list, va_start and va_end
+#include <sys/syscall.h> // for SYS_gettid
 #include <assert.h>
 #include <errno.h>
 #include <math.h>
 #include "recorder.h"
 #include "recorder-utils.h"
-
 
 // Log pointer addresses in the trace file?
 static bool   log_pointer = false;
@@ -167,6 +168,15 @@ inline int accept_filename(const char *filename) {
     }
 
     return 1;
+}
+
+inline pthread_t recorder_gettid(void)
+{
+#ifdef SYS_gettid
+    return syscall(SYS_gettid);
+#else
+    return pthread_self();
+#endif
 }
 
 inline long get_file_size(const char *filename) {

--- a/tools/reader.c
+++ b/tools/reader.c
@@ -17,21 +17,13 @@ void read_metadata(RecorderReader* reader) {
     FILE* fp = fopen(metadata_file, "rb");
     assert(fp != NULL);
     fread(&reader->metadata, sizeof(reader->metadata), 1, fp);
-    fclose(fp);
-}
 
-void read_func_list(RecorderReader *reader) {
-    char metadata_file[1024];
-    snprintf(metadata_file, sizeof(metadata_file), "%s/recorder.mt", reader->logs_dir);
-
-    FILE* fp = fopen(metadata_file, "rb");
-    assert(fp != NULL);
-
+    long pos = ftell(fp);
     fseek(fp, 0, SEEK_END);
-    long fsize = ftell(fp) - sizeof(reader->metadata);
+    long fsize = ftell(fp) - pos;
     char buf[fsize];
 
-    fseek(fp, sizeof(reader->metadata), SEEK_SET); // skip RecorderMetadata object
+    fseek(fp, pos, SEEK_SET);
     fread(buf, 1, fsize, fp);
 
     int start_pos = 0, end_pos = 0;
@@ -66,7 +58,6 @@ void recorder_init_reader(const char* logs_dir, RecorderReader *reader) {
     strcpy(reader->logs_dir, logs_dir);
 
     read_metadata(reader);
-    read_func_list(reader);
 }
 
 void recorder_free_reader(RecorderReader *reader) {

--- a/tools/reader.c
+++ b/tools/reader.c
@@ -52,15 +52,21 @@ void read_func_list(char* path, RecorderReader *reader) {
 }
 
 void recorder_init_reader(const char* logs_dir, RecorderReader *reader) {
-    char metadata_file[1024];
+    assert(logs_dir);
+    assert(reader);
+
+    memset(reader, 0, sizeof(*reader));
     strcpy(reader->logs_dir, logs_dir);
 
+    char metadata_file[1024];
     sprintf(metadata_file, "%s/recorder.mt", logs_dir);
     read_metadata(metadata_file, &reader->metadata);
     read_func_list(metadata_file, reader);
 }
 
 void recorder_free_reader(RecorderReader *reader) {
+    assert(reader);
+    memset(reader, 0, sizeof(*reader));
 }
 
 const char* recorder_get_func_name(RecorderReader* reader, Record* record) {

--- a/tools/reader.c
+++ b/tools/reader.c
@@ -5,6 +5,22 @@
 #include <assert.h>
 #include "./reader.h"
 
+void check_version(RecorderReader* reader) {
+    char version_file[1024];
+    snprintf(version_file, sizeof(version_file), "%s/VERSION", reader->logs_dir);
+
+    FILE* fp = fopen(version_file, "r");
+    assert(fp != NULL);
+    int major, minor, patch;
+    fscanf(fp, "%d.%d.%d", &major, &minor, &patch);
+    if(major != VERSION_MAJOR || minor != VERSION_MINOR) {
+        fprintf(stderr, "incompatible version: file=%d.%d.%d != reader=%d.%d.%d\n",
+                major, minor, patch, VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
+        exit(1);
+    }
+    fclose(fp);
+}
+
 void read_metadata(RecorderReader* reader) {
     char metadata_file[1024];
     snprintf(metadata_file, sizeof(metadata_file), "%s/recorder.mt", reader->logs_dir);
@@ -54,6 +70,8 @@ void recorder_init_reader(const char* logs_dir, RecorderReader *reader) {
     reader->mpi_start_idx = -1;
     reader->hdf5_start_idx = -1;
     reader->prev_tstart = 0.0;
+
+    check_version(reader);
 
     read_metadata(reader);
 }

--- a/tools/reader.h
+++ b/tools/reader.h
@@ -19,6 +19,11 @@ typedef struct RecorderReader_t {
 
     char func_list[256][64];
     char logs_dir[1024];
+
+    int mpi_start_idx;
+    int hdf5_start_idx;
+
+    double prev_tstart;
 } RecorderReader;
 
 typedef struct Interval_t {

--- a/tools/reader.h
+++ b/tools/reader.h
@@ -3,6 +3,11 @@
 #include <stdbool.h>
 #include "recorder-logger.h"
 
+// keep in sync with VERSION_STR in lib/recorder-logger.c
+// equal (major, minor) is needed for compatibility
+#define VERSION_MAJOR 2
+#define VERSION_MINOR 3
+#define VERSION_PATCH 3
 
 #define POSIX_SEMANTICS 0
 #define COMMIT_SEMANTICS 1

--- a/tools/recorder2timeline.cpp
+++ b/tools/recorder2timeline.cpp
@@ -57,12 +57,18 @@ void write_to_json(Record *record, void* arg) {
             << "\",\"cat\":\""  << type_name(cat)
             << "\",\"ph\":\"X\""
             << ",\"dur\":"      << dur
-            << ",\"args\":\"";
-        for (int arg_id = 0; !user_func && arg_id < record->arg_count; arg_id++) {
-            char *arg = record->args[arg_id];
-            ss  << " " << arg;
+            << ",\"args\":{";
+        if (!user_func) {
+            ss  << "\"args\":[";
+            const char* sep = "";
+            for (int arg_id = 0; arg_id < record->arg_count; arg_id++) {
+                char *arg = record->args[arg_id];
+                ss << sep << "\"" << arg << "\"";
+                sep = ",";
+            }
+            ss  << "],";
         }
-        ss << " tend: " << record->tend << "\"}";
+        ss << "\"tend\": \"" << record->tend << "\"}}";
         writer->outFile << ss.rdbuf();
         writer->sep = ",\n";
     }

--- a/tools/recorder2timeline.cpp
+++ b/tools/recorder2timeline.cpp
@@ -35,7 +35,7 @@ void write_to_json(Record *record, void* arg) {
         if (dur <= 0) dur = 0;
         std::stringstream ss;
         ss  << "{\"pid\":"      << writer->rank
-            << ",\"tid\":"      << cat
+            << ",\"tid\":"      << tid
             << ",\"ts\":"       << ts
             << ",\"name\":\""   << func_name
             << "\",\"cat\":\""  << cat

--- a/tools/recorder2timeline.cpp
+++ b/tools/recorder2timeline.cpp
@@ -37,15 +37,15 @@ void write_to_json(Record *record, void* arg) {
             << ",\"tid\":"      << cat
             << ",\"ts\":"       << ts
             << ",\"name\":\""   << func_name
-            << "\",\"cat\":\""  << cat;
-            ss  << "\",\"ph\":\"X\""<< ""
-                << ",\"dur\":"      << dur;
-        ss  <<",\"args\":\"";
+            << "\",\"cat\":\""  << cat
+            << "\",\"ph\":\"X\""
+            << ",\"dur\":"      << dur
+            << ",\"args\":\"";
         for (int arg_id = 0; !user_func && arg_id < record->arg_count; arg_id++) {
             char *arg = record->args[arg_id];
             ss  << " " << arg;
         }
-        ss  << " tend: "<< record->tend  <<"\"},\n";
+        ss << " tend: " << record->tend << "\"},\n";
         writer->outFile << ss.rdbuf();
     }
 }

--- a/tools/recorder2timeline.cpp
+++ b/tools/recorder2timeline.cpp
@@ -55,24 +55,25 @@ int max(int a, int b) { return a > b ? a : b; }
 
 int main(int argc, char **argv) {
 
-    char textfile_dir[256];
-    char textfile_path[256];
-    sprintf(textfile_dir, "%s/_chrome", argv[1]);
-    recorder_init_reader(argv[1], &reader);
     int mpi_size, mpi_rank;
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
+    char textfile_dir[256];
+    sprintf(textfile_dir, "%s/_chrome", argv[1]);
+
     if(mpi_rank == 0)
         mkdir(textfile_dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     MPI_Barrier(MPI_COMM_WORLD);
+
     recorder_init_reader(argv[1], &reader);
 
     // Each rank will process n files (n ranks traces)
     int n = max(reader.metadata.total_ranks/mpi_size, 1);
     int start_rank = n * mpi_rank;
     int end_rank   = min(reader.metadata.total_ranks, n*(mpi_rank+1));
+    char textfile_path[256];
     sprintf(textfile_path, "%s/timeline_%d.json", textfile_dir, mpi_rank);
     Writer local;
     local.outFile.open(textfile_path, std::ofstream::trunc|std::ofstream::out);

--- a/tools/recorder2timeline.cpp
+++ b/tools/recorder2timeline.cpp
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <sstream>
 #include <fstream>
+#include <iostream>
 
 RecorderReader reader;
 
@@ -54,6 +55,11 @@ int min(int a, int b) { return a < b ? a : b; }
 int max(int a, int b) { return a > b ? a : b; }
 
 int main(int argc, char **argv) {
+
+    if(argc!=2) {
+        std::cerr << "Usage: " << argv[0] << " <directory-of-recorder.mt>\n";
+        std::exit(1);
+    }
 
     int mpi_size, mpi_rank;
     MPI_Init(&argc, &argv);

--- a/tools/recorder2timeline.cpp
+++ b/tools/recorder2timeline.cpp
@@ -19,6 +19,21 @@ struct Writer{
     int rank, my_rank, total_ranks;
 };
 
+static const char* type_name(int type) {
+    switch (type) {
+        case RECORDER_POSIX:
+            return "POSIX";
+        case RECORDER_MPIIO:
+            return "MPI I/O";
+        case RECORDER_MPI:
+            return "MPI";
+        case RECORDER_HDF5:
+            return "HDF5";
+        case RECORDER_FTRACE:
+            return "USER";
+    }
+}
+
 void write_to_json(Record *record, void* arg) {
 
    int cat = recorder_get_func_type(&reader, record);
@@ -38,7 +53,7 @@ void write_to_json(Record *record, void* arg) {
             << ",\"tid\":"      << tid
             << ",\"ts\":"       << ts
             << ",\"name\":\""   << func_name
-            << "\",\"cat\":\""  << cat
+            << "\",\"cat\":\""  << type_name(cat)
             << "\",\"ph\":\"X\""
             << ",\"dur\":"      << dur
             << ",\"args\":\"";


### PR DESCRIPTION
Current timestamps are 10× larger than expected.

Timestamps from Recorder are in seconds and are converted with the timer resolution of the file. Which defaults to 1e-7. Chrome traces expect microseconds as timestamp, optional with a nanosecond fraction.

Ignore timer resolution from Recorder and just convert to microseconds and format them as double with precision 3.

While at it I made some improvements for a completely new user to Recorder traces converted to Chrome traces.